### PR TITLE
method not found exception when using DateGenerator(minDate,maxDate)

### DIFF
--- a/src/main/groovy/spock/genesis/generators/values/DateGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/values/DateGenerator.groovy
@@ -11,7 +11,7 @@ class DateGenerator extends InfiniteGenerator<Date> {
 	}
 	
 	DateGenerator(Date minDate, Date maxDate) {
-		this.millisProvider = new LongGenerator(minDate.millis(), maxDate.millis())
+		this.millisProvider = new LongGenerator(minDate.time, maxDate.time)
 	}
 	
 	@Override

--- a/src/test/groovy/spock/genesis/generators/values/DateGeneratorSpec.groovy
+++ b/src/test/groovy/spock/genesis/generators/values/DateGeneratorSpec.groovy
@@ -1,0 +1,22 @@
+package spock.genesis.generators.values
+
+import groovy.time.TimeCategory
+import spock.lang.Specification
+
+class DateGeneratorSpec extends Specification {
+	
+	def 'generate in range'() {
+		setup:
+			final sample = 10
+		when:
+			def generator = new DateGenerator(low, high)
+			def results = generator.take(sample).realized
+		
+		then:
+			results.size() == sample
+			results.every { it <= high && it >= low }
+		where:
+			low | high
+			new Date() | new Date() + 10 
+	}
+}


### PR DESCRIPTION
I was getting errors when I tried to use the  DateGenerator with upper and lower bounds, so I changed DateGenerator to use .getTime() instead of millis().  I also wrote a unit test to verify this behavior.

(was running original in jdk 1.7.x, groovy 2.3)
