### PR TITLE
make GeneratorDecorator only decorate Generators

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
         classpath 'org.ajoberstar:gradle-git:1.4.2'
     }
@@ -31,6 +31,7 @@ dependencies {
     compile('org.codehaus.groovy:groovy-all:2.4.7')
     compile('org.spockframework:spock-core:1.0-groovy-2.4')
     compile('com.github.mifmif:generex:1.0.1')
+    testCompile('cglib:cglib-nodep:3.2.4')
 }
 
 asciidoctor {
@@ -107,7 +108,7 @@ bintray {
         repo = 'nagternal'
         name = 'spock-genesis'
         desc = 'Mostly lazy data generators for property based testing using the Spock test framework'
-        websiteUrl = 'https://github.com/Bijnagte/spock-genesis'
+        websiteUrl = 'https://bijnagte.github.io/spock-genesis'
         issueTrackerUrl = 'https://github.com/Bijnagte/spock-genesis/issues'
         vcsUrl = 'https://github.com/Bijnagte/spock-genesis.git'
         licenses = ['MIT']

--- a/src/main/groovy/spock/genesis/Gen.groovy
+++ b/src/main/groovy/spock/genesis/Gen.groovy
@@ -3,6 +3,7 @@ package spock.genesis
 import spock.genesis.generators.CyclicGenerator
 import spock.genesis.generators.FactoryGenerator
 import spock.genesis.generators.Generator
+import spock.genesis.generators.IterableGenerator
 import spock.genesis.generators.composites.DefinedMapGenerator
 import spock.genesis.generators.composites.ListGenerator
 import spock.genesis.generators.composites.PojoGenerator
@@ -227,24 +228,13 @@ class Gen {
 
     /**
      * Produces a lazy infinite {@link CyclicGenerator} that repeats
-     * an {@link Iterator}.
-     *
-     * @param source {@link Iterator} to repeat over
-     * @return an instance of {@link CyclicGenerator}
-     */
-    static CyclicGenerator cycle(Iterator source) {
-        new CyclicGenerator(source)
-    }
-
-    /**
-     * Produces a lazy infinite {@link CyclicGenerator} that repeats
      * an {@link Iterable}.
      *
      * @param source {@link Iterable} to repeat over
      * @return an instance of {@link CyclicGenerator}
      */
     static <T> CyclicGenerator cycle(Iterable<T> source) {
-        new CyclicGenerator<T>(source)
+        new IterableGenerator<T>(source).repeat()
     }
 
     /**

--- a/src/main/groovy/spock/genesis/extension/ExtensionMethods.groovy
+++ b/src/main/groovy/spock/genesis/extension/ExtensionMethods.groovy
@@ -2,8 +2,7 @@ package spock.genesis.extension
 
 import groovy.transform.CompileStatic
 import spock.genesis.generators.Generator
-import spock.genesis.generators.GeneratorDecorator
-import spock.genesis.generators.LimitedGenerator
+import spock.genesis.generators.IterableGenerator
 import spock.genesis.generators.ObjectIteratorGenerator
 
 @CompileStatic
@@ -18,15 +17,23 @@ class ExtensionMethods {
     }
 
     static <T> Generator<T> toGenerator(Iterable<T> self, boolean finite = false) {
-        new GeneratorDecorator<T>(self, finite)
+        new IterableGenerator<T>(self, finite)
     }
 
     static Generator<String> toGenerator(String self) {
         new ObjectIteratorGenerator<String>(self)
     }
 
+    static Generator<Object> toGenerator(Object self) {
+        new ObjectIteratorGenerator(self)
+    }
+
+    static <K,V> Generator<Map.Entry<K,V>> toGenerator(Map<K,V> self) {
+        new ObjectIteratorGenerator(self)
+    }
+
     static <T> Generator<T> toGenerator(Collection<T> self) {
-        new LimitedGenerator<T>(self)
+        new IterableGenerator<T>(self)
     }
 
     static Generator toGenerator(Class clazz) {
@@ -38,11 +45,11 @@ class ExtensionMethods {
     }
 
     static <T> Generator<T> toGenerator(T... self) {
-        new LimitedGenerator<T>(self)
+        new IterableGenerator<T>(self)
     }
 
-    static Generator toGenerator(Iterator self) {
-        new GeneratorDecorator(new Iterable() {
+    static <T> Generator<T> toGenerator(Iterator<T> self) {
+        new IterableGenerator<T>(new Iterable () {
             @Override
             Iterator iterator() {
                 self

--- a/src/main/groovy/spock/genesis/generators/CyclicGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/CyclicGenerator.groovy
@@ -1,6 +1,7 @@
 package spock.genesis.generators
 
 import groovy.transform.CompileStatic
+import spock.genesis.extension.ExtensionMethods
 
 /**
  * A lazy infinite generator that repeats an iterator.
@@ -15,7 +16,7 @@ class CyclicGenerator<E> extends GeneratorDecorator<E> {
     }
 
     CyclicGenerator(Iterable<E> iterable) {
-        super(iterable, GeneratorUtils.isFinite(iterable) || !Generator.isInstance(iterable))
+        super(ExtensionMethods.toGenerator(iterable))
     }
 
     @Override

--- a/src/main/groovy/spock/genesis/generators/FilteredGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/FilteredGenerator.groovy
@@ -1,6 +1,7 @@
 package spock.genesis.generators
 
 import groovy.transform.CompileStatic
+import spock.genesis.extension.ExtensionMethods
 
 /**
  * A lazy generator that returns the next value from the wrapped iterator that satisfies a predicate Closure.
@@ -12,7 +13,7 @@ class FilteredGenerator<E> extends GeneratorDecorator<E> {
     private final Closure predicate
 
     FilteredGenerator(Iterable<E> iterable, Closure predicate) {
-        super(iterable)
+        super(ExtensionMethods.toGenerator(iterable))
         this.predicate = predicate
     }
 

--- a/src/main/groovy/spock/genesis/generators/Generator.groovy
+++ b/src/main/groovy/spock/genesis/generators/Generator.groovy
@@ -7,9 +7,8 @@ import spock.genesis.generators.values.NullGenerator
  * An Iterator that generates a type (usually lazily)
  * @param < E >   the generated type
  */
-@SuppressWarnings('SpaceAroundMapEntryColon')
 @CompileStatic
-abstract class Generator<E> implements Iterable<E> {
+abstract class Generator<E> implements Iterable<E>, Closeable {
 
     /**
      * Wraps this generator in a generator that returns values that matches the supplied predicate
@@ -40,7 +39,7 @@ abstract class Generator<E> implements Iterable<E> {
         Iterable<E>[] all = new Iterable<E>[iterables.length + 1]
         all[0] = this
         for (int i = 0; i < iterables.length; i++) {
-            all[i +1] = iterables[i]
+            all[i + 1] = iterables[i]
 
         }
         new SequentialMultisourceGenerator<E>(all)
@@ -66,6 +65,7 @@ abstract class Generator<E> implements Iterable<E> {
      * @param resultsPerNull the average number of results from this generator per null result
      * @return {@link spock.genesis.generators.MultiSourceGenerator}
      */
+    @SuppressWarnings('SpaceAroundMapEntryColon')
     MultiSourceGenerator<E> withNulls(int resultsPerNull) {
         Map weightedGenerators = [(this): resultsPerNull, (new NullGenerator<E>()): 1]
         new MultiSourceGenerator<E>(weightedGenerators)
@@ -85,9 +85,14 @@ abstract class Generator<E> implements Iterable<E> {
      * If false then the generator may still terminate when iterated
      * @return true if the Generator will terminate
      */
-    abstract boolean isFinite()
+    boolean isFinite() {
+        !iterator().hasNext()
+    }
 
     List<E> getRealized() {
         this.collect().asList()
     }
+
+    @SuppressWarnings('EmptyMethodInAbstractClass')
+    void close() { }
 }

--- a/src/main/groovy/spock/genesis/generators/GeneratorDecorator.groovy
+++ b/src/main/groovy/spock/genesis/generators/GeneratorDecorator.groovy
@@ -1,24 +1,23 @@
 package spock.genesis.generators
 
-import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 
 /**
- * A generator that wraps an iterator to provide {@link Generator} methods.
+ * Base {@link Generator} class for functionality that modifies a stream from the wrapped generator.
  * @param < E >   the generated type
  */
 @CompileStatic
 class GeneratorDecorator<E> extends Generator<E> implements Closeable {
-    protected Iterable<E> generator
+    protected Generator<E> generator
     final boolean finiteOverride
 
-    GeneratorDecorator(Iterable<E> iterable) {
-        this.generator = iterable
-        this.finiteOverride = false
+    GeneratorDecorator(Generator<E> generator) {
+        this.generator = generator
+        this.finiteOverride = generator.finite
     }
 
-    GeneratorDecorator(Iterable<E> iterable, boolean finite) {
-        this.generator = iterable
+    GeneratorDecorator(Generator<E> generator, boolean finite) {
+        this.generator = generator
         this.finiteOverride = finite
     }
 
@@ -41,13 +40,10 @@ class GeneratorDecorator<E> extends Generator<E> implements Closeable {
 
     @Override
     boolean isFinite() {
-        finiteOverride || GeneratorUtils.isFinite(generator)
+        finiteOverride || !generator.iterator().hasNext()
     }
 
-    @CompileDynamic
     void close() {
-        if (generator.respondsTo('close')) {
-            generator.close()
-        }
+        generator.close()
     }
 }

--- a/src/main/groovy/spock/genesis/generators/IterableGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/IterableGenerator.groovy
@@ -1,0 +1,59 @@
+package spock.genesis.generators
+
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+
+/**
+ * A generator that wraps an iterator to provide {@link Generator} methods.
+ * @param < E >   the generated type
+ */
+@CompileStatic
+class IterableGenerator<E> extends Generator<E> implements Closeable {
+
+    private final Iterable<E> iterable
+    private final boolean finite
+
+    IterableGenerator(Iterable<E> iterable) {
+        this.iterable = iterable
+        this.finite = Generator.isInstance(iterable) ? false : true
+    }
+
+    IterableGenerator(Iterable<E> iterable, boolean finite) {
+        this.iterable = iterable
+        this.finite = finite
+    }
+
+    IterableGenerator(E... array) {
+        this.iterable = Arrays.asList(array)
+        this.finite = true
+    }
+
+    @Override
+    UnmodifiableIterator<E> iterator() {
+        new UnmodifiableIterator<E>() {
+            private final Iterator<E> iterator = iterable.iterator()
+            @Override
+            boolean hasNext() {
+                iterator.hasNext()
+            }
+
+            @Override
+            E next() {
+                iterator.next()
+            }
+        }
+    }
+
+    @Override
+    boolean isFinite() {
+        finite || GeneratorUtils.isFinite(iterable)
+    }
+
+    @CompileDynamic
+    @Override
+    void close() {
+        if (iterable.respondsTo('close')) {
+            iterable.close()
+        }
+    }
+}

--- a/src/main/groovy/spock/genesis/generators/LimitedGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/LimitedGenerator.groovy
@@ -1,6 +1,7 @@
 package spock.genesis.generators
 
 import groovy.transform.CompileStatic
+import spock.genesis.extension.ExtensionMethods
 
 @CompileStatic
 class LimitedGenerator<E> extends GeneratorDecorator<E> {
@@ -8,18 +9,8 @@ class LimitedGenerator<E> extends GeneratorDecorator<E> {
     final int iterationLimit
 
     LimitedGenerator(Iterable<E> iterable, int iterationLimit) {
-        super(iterable)
+        super(ExtensionMethods.toGenerator(iterable))
         this.iterationLimit = iterationLimit
-    }
-
-    LimitedGenerator(Collection<E> collection) {
-        super(collection)
-        this.iterationLimit = collection.size()
-    }
-
-    LimitedGenerator(E... array) {
-        super(Arrays.asList(array))
-        this.iterationLimit = array.length
     }
 
     UnmodifiableIterator<E> iterator() {

--- a/src/main/groovy/spock/genesis/generators/TransformingGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/TransformingGenerator.groovy
@@ -1,23 +1,26 @@
 package spock.genesis.generators
 
-class TransformingGenerator<E, T> extends GeneratorDecorator<T> {
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class TransformingGenerator<E, T> extends GeneratorDecorator<E> {
     private final Closure<T> transform
 
-    TransformingGenerator(Iterable<E> iterable, Closure<T> transform) {
+    TransformingGenerator(Generator<E> iterable, Closure<T> transform) {
         super(iterable)
         this.transform = transform
     }
 
-    UnmodifiableIterator<E> iterator() {
-        final Iterator<E> ITERATOR = super.iterator()
-        new UnmodifiableIterator<E>() {
+    UnmodifiableIterator<T> iterator() {
+        final Iterator<T> ITERATOR = super.iterator()
+        new UnmodifiableIterator<T>() {
             @Override
             boolean hasNext() {
                 ITERATOR.hasNext()
             }
 
             T next() {
-                transform(ITERATOR.next())
+                transform.call(ITERATOR.next())
             }
         }
     }

--- a/src/main/groovy/spock/genesis/generators/composites/ListGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/composites/ListGenerator.groovy
@@ -5,7 +5,6 @@ import spock.genesis.generators.GeneratorDecorator
 import spock.genesis.generators.UnmodifiableIterator
 import spock.genesis.generators.values.WholeNumberGenerator
 
-
 class ListGenerator<E> extends GeneratorDecorator<List<E>> {
 
     static final int DEFAULT_LENGTH_LIMIT = 1000

--- a/src/main/groovy/spock/genesis/transform/GenASTTransformation.groovy
+++ b/src/main/groovy/spock/genesis/transform/GenASTTransformation.groovy
@@ -132,9 +132,9 @@ class GenASTTransformation implements ASTTransformation {
             def value = iterationsAnnotation.getMember('value')
             if (value instanceof ConstantExpression) {
                 ConstantExpression valueExpression = (ConstantExpression) value
-                return (Integer) valueExpression.value
+                (Integer) valueExpression.value
             } else {
-                return 100
+                100
             }
         }
     }

--- a/src/test/groovy/spock/genesis/generators/GeneratorDecoratorSpec.groovy
+++ b/src/test/groovy/spock/genesis/generators/GeneratorDecoratorSpec.groovy
@@ -1,24 +1,13 @@
 package spock.genesis.generators
 
-import spock.genesis.generators.test.CloseableIterable
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class GeneratorDecoratorSpec extends Specification {
 
-    def 'calling close does nothing if wrapped generator does not have a close'() {
-        setup:
-            Iterable wrapped = Mock()
-            def generator = new GeneratorDecorator(wrapped)
-        when:
-            generator.close()
-        then:
-            0 * wrapped._
-    }
-
     def 'calling close closes wrapped generator'() {
         setup:
-            CloseableIterable wrapped = Mock()
+            Generator wrapped = Mock()
             def generator = new GeneratorDecorator(wrapped)
         when:
             generator.close()
@@ -28,8 +17,8 @@ class GeneratorDecoratorSpec extends Specification {
 
     def 'has next delegates to wrapped generator'() {
         setup:
-            Iterator iterator = Mock()
-            Iterable wrapped = Mock()
+            UnmodifiableIterator iterator = Mock()
+            Generator wrapped = Mock()
             def generator = new GeneratorDecorator(wrapped)
         when:
             generator.iterator().hasNext()
@@ -37,13 +26,12 @@ class GeneratorDecoratorSpec extends Specification {
             1 * wrapped.iterator() >> iterator
             1 * iterator.hasNext()
             0 * _
-
     }
 
     def 'next delegates to wrapped generator'() {
         setup:
-            Iterator iterator = Mock()
-            Iterable wrapped = Mock()
+            UnmodifiableIterator iterator = Mock()
+            Generator wrapped = Mock()
             def generator = new GeneratorDecorator(wrapped)
         when:
             generator.iterator().next()
@@ -56,29 +44,25 @@ class GeneratorDecoratorSpec extends Specification {
     @Unroll
     def 'isFinite if specified as such or wrapped iterator is finite '() {
         setup:
-            def generator = overrideFinite ? new GeneratorDecorator(wrapped, overrideFinite) : new GeneratorDecorator(wrapped)
+            def generator = overrideFinite != null ? new GeneratorDecorator<>(wrapped, overrideFinite) : new GeneratorDecorator<>(wrapped)
         expect:
             generator.isFinite() == expected
         where:
             overrideFinite | wrapped                                                    || expected
-            false          | []                                                         || true
-            false          | [1]                                                        || false
-            true           | [1]                                                        || true
             true           | new TestGenerator(finiteValue: false, hasNextValue: true)  || true
-            false          | new TestGenerator(finiteValue: false, hasNextValue: true)  || false
-            false          | new TestGenerator(finiteValue: false, hasNextValue: false) || true
-            false          | new TestGenerator(finiteValue: true, hasNextValue: true)   || true
+            null           | new TestGenerator(finiteValue: false, hasNextValue: true)  || false
+            null           | new TestGenerator(finiteValue: false, hasNextValue: false) || true
+            null           | new TestGenerator(finiteValue: true, hasNextValue: true)   || true
     }
 
-    class TestGenerator implements Iterable {
+    class TestGenerator extends Generator {
         boolean finiteValue
         boolean hasNextValue
 
-        Iterator iterator() {
-            new Iterator() {
+        UnmodifiableIterator iterator() {
+            new UnmodifiableIterator() {
                 boolean hasNext() { hasNextValue }
                 def next() { assert false }
-                void remove() { assert false }
             }
         }
         boolean isFinite() { finiteValue }

--- a/src/test/groovy/spock/genesis/generators/GeneratorUtilsSpec.groovy
+++ b/src/test/groovy/spock/genesis/generators/GeneratorUtilsSpec.groovy
@@ -1,6 +1,5 @@
 package spock.genesis.generators
 
-import spock.genesis.generators.composites.TupleGenerator
 import spock.genesis.generators.values.IntegerGenerator
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -23,8 +22,8 @@ class GeneratorUtilsSpec extends Specification {
             [['a', 'b'], [1, 2], [5, 6, 7]]             || false
             [[]]                                        || true
             [[], [1, 2, 3, 4, 5]]                       || false
-            [new LimitedGenerator([1, 2, 3, 4, 5])]     || true
-            [new LimitedGenerator([1, 2, 3, 4, 5]), []] || true
+            [new IterableGenerator([1, 2, 3, 4, 5])]     || true
+            [new IterableGenerator([1, 2, 3, 4, 5]), []] || true
             [new IntegerGenerator(), []]                || false
     }
 
@@ -37,8 +36,8 @@ class GeneratorUtilsSpec extends Specification {
             [['a', 'b'], [1, 2], [5, 6, 7]]             || false
             [[]]                                        || true
             [[], [1, 2, 3, 4, 5]]                       || true
-            [new LimitedGenerator([1, 2, 3, 4, 5])]     || true
-            [new LimitedGenerator([1, 2, 3, 4, 5]), []] || true
+            [new IterableGenerator([1, 2, 3, 4, 5])]     || true
+            [new IterableGenerator([1, 2, 3, 4, 5]), []] || true
             [new IntegerGenerator(), []]                || true
     }
 

--- a/src/test/groovy/spock/genesis/generators/IterableGeneratorSpec.groovy
+++ b/src/test/groovy/spock/genesis/generators/IterableGeneratorSpec.groovy
@@ -1,0 +1,65 @@
+package spock.genesis.generators
+
+import spock.genesis.generators.test.CloseableIterable
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class IterableGeneratorSpec extends Specification {
+    def 'Iterable and array constructors iterate complete source'() {
+        expect:
+            new IterableGenerator([1, 2, 3]).realized == [1, 2, 3]
+            new IterableGenerator([1, 2, 3].toSet()).realized == [1, 2, 3]
+            new IterableGenerator([1, 2, 3].toArray()).realized == [1, 2, 3]
+    }
+
+    def 'calling close does nothing if wrapped generator does not have a close'() {
+        setup:
+            Iterable wrapped = Mock()
+            def generator = new IterableGenerator(wrapped)
+        when:
+            generator.close()
+        then:
+            0 * wrapped._
+    }
+
+    def 'calling close closes wrapped iterable'() {
+        setup:
+            CloseableIterable wrapped = Mock()
+            def generator = new IterableGenerator(wrapped)
+        when:
+            generator.close()
+        then:
+            1 * wrapped.close()
+    }
+
+    @Unroll
+    def 'isFinite if specified as such or wrapped iterator is finite '() {
+        setup:
+            def generator = overrideFinite != null ? new IterableGenerator(wrapped, overrideFinite) : new IterableGenerator(wrapped)
+        expect:
+            generator.isFinite() == expected
+        where:
+            overrideFinite | wrapped                                                    || expected
+            false          | []                                                         || true
+            null           | [1]                                                        || true
+            true           | [1]                                                        || true
+            false          | [1]                                                        || false
+            true           | new TestGenerator(finiteValue: false, hasNextValue: true)  || true
+            null           | new TestGenerator(finiteValue: false, hasNextValue: true)  || false
+            null           | new TestGenerator(finiteValue: false, hasNextValue: false) || true
+            null           | new TestGenerator(finiteValue: true, hasNextValue: true)   || true
+    }
+
+    class TestGenerator extends Generator {
+        boolean finiteValue
+        boolean hasNextValue
+
+        UnmodifiableIterator iterator() {
+            new UnmodifiableIterator() {
+                boolean hasNext() { hasNextValue }
+                def next() { assert false }
+            }
+        }
+        boolean isFinite() { finiteValue }
+    }
+}

--- a/src/test/groovy/spock/genesis/generators/LimitedGeneratorSpec.groovy
+++ b/src/test/groovy/spock/genesis/generators/LimitedGeneratorSpec.groovy
@@ -4,8 +4,8 @@ import spock.lang.Specification
 
 class LimitedGeneratorSpec extends Specification {
 
-    Iterable wrapped = Mock()
-    Iterator iterator = Mock()
+    Generator wrapped = Mock()
+    UnmodifiableIterator iterator = Mock()
 
     def setup() {
         wrapped.iterator() >> iterator
@@ -40,12 +40,5 @@ class LimitedGeneratorSpec extends Specification {
     def 'is finite'() {
         expect:
             new LimitedGenerator(wrapped, 20).isFinite() == true
-    }
-
-    def 'collection and array constructors iterate complete source'() {
-        expect:
-            new LimitedGenerator([1, 2, 3]).realized == [1, 2, 3]
-            new LimitedGenerator([1, 2, 3].toSet()).realized == [1, 2, 3]
-            new LimitedGenerator([1, 2, 3].toArray()).realized == [1, 2, 3]
     }
 }

--- a/src/test/groovy/spock/genesis/generators/TransformingGeneratorSpec.groovy
+++ b/src/test/groovy/spock/genesis/generators/TransformingGeneratorSpec.groovy
@@ -4,8 +4,8 @@ import spock.lang.Specification
 
 class TransformingGeneratorSpec extends Specification {
 
-    Iterator iterator = Mock()
-    Iterable supplier = Stub {
+    UnmodifiableIterator iterator = Mock()
+    Generator supplier = Stub {
         iterator() >> iterator
     }
 


### PR DESCRIPTION
This is necessary for the ability to seed randoms #16 without introducing less maintainable logic.  Unfortunately because of the nesting of generators (which is necessary for laziness) setting the seed will need to call through the wrapping / containing generators.

cc @mariogarcia 
