### PR TITLE
resolves #4 generate permutations

### DIFF
--- a/src/main/groovy/spock/genesis/Gen.groovy
+++ b/src/main/groovy/spock/genesis/Gen.groovy
@@ -236,7 +236,7 @@ class Gen {
      * @param target type of the object we would like to generate
      * @return an instance of {@link PojoGenerator}
      */
-    static <T> PojoGenerator<T,Map> type(Map<String, Object> keysToValueGenerators, T target) {
+    static <T> PojoGenerator<T,Map> type(Map<String, Object> keysToValueGenerators, Class<T> target) {
         new PojoGenerator(target, map(keysToValueGenerators))
     }
 
@@ -248,7 +248,7 @@ class Gen {
      * @param argGenerators generators per each field
      * @return an instance of {@link PojoGenerator}
      */
-    static <T> PojoGenerator<T, List> type(T target, Iterable... argGenerators) {
+    static <T> PojoGenerator<T, List> type(Class<T> target, Iterable... argGenerators) {
         new PojoGenerator(target, tuple(argGenerators))
     }
 

--- a/src/main/groovy/spock/genesis/generators/Generator.groovy
+++ b/src/main/groovy/spock/genesis/generators/Generator.groovy
@@ -21,6 +21,7 @@ abstract class Generator<E> implements Iterable<E>, Closeable {
         new FilteredGenerator<E>(this, predicate)
     }
 
+    @SuppressWarnings(['UnnecessaryPublicModifier']) // needed for generic parsing issue
     public <T> TransformingGenerator<E, T> map(Closure<T> transform) {
         new TransformingGenerator<E, T>(this, transform)
     }

--- a/src/main/groovy/spock/genesis/generators/Permutable.groovy
+++ b/src/main/groovy/spock/genesis/generators/Permutable.groovy
@@ -1,0 +1,6 @@
+package spock.genesis.generators
+
+interface Permutable<T> extends Iterable {
+    Generator<T> permute()
+    Generator<T> permute(int maxDepth)
+}

--- a/src/main/groovy/spock/genesis/generators/composites/DefinedMapGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/composites/DefinedMapGenerator.groovy
@@ -2,10 +2,11 @@ package spock.genesis.generators.composites
 
 import groovy.transform.CompileStatic
 import spock.genesis.generators.Generator
+import spock.genesis.generators.Permutable
 import spock.genesis.generators.UnmodifiableIterator
 
 @CompileStatic
-class DefinedMapGenerator<K, V> extends Generator<Map<K, V>> {
+class DefinedMapGenerator<K, V> extends Generator<Map<K, V>> implements Permutable {
 
     private final List<K> keys
     private final TupleGenerator<V> valuesGenerator
@@ -45,7 +46,7 @@ class DefinedMapGenerator<K, V> extends Generator<Map<K, V>> {
             Map<K, V> next() {
                 List values = iterator.next()
                 Map<K,V> result = [:]
-                keys.eachWithIndex{ K key, int i ->
+                keys.eachWithIndex { K key, int i ->
                     result[key] = values[i]
                 }
                 result

--- a/src/main/groovy/spock/genesis/generators/composites/DefinedMapGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/composites/DefinedMapGenerator.groovy
@@ -1,54 +1,73 @@
 package spock.genesis.generators.composites
 
 import groovy.transform.CompileStatic
-import spock.genesis.extension.ExtensionMethods
 import spock.genesis.generators.Generator
 import spock.genesis.generators.UnmodifiableIterator
 
 @CompileStatic
 class DefinedMapGenerator<K, V> extends Generator<Map<K, V>> {
 
-    final Map<K, Generator<V>> keysToValueGenerators
+    private final List<K> keys
+    private final TupleGenerator<V> valuesGenerator
 
     DefinedMapGenerator(Map<K, Iterable<V>> keysToValueGenerators) {
-        Map<K, Generator<V>> collector = [:]
-        this.keysToValueGenerators = keysToValueGenerators.collectEntries(collector) { key, generator ->
-            [key, ExtensionMethods.toGenerator(generator)]
-        }.asImmutable()
+        List keys = []
+        List iterables = []
+        keysToValueGenerators.each { key, iterable ->
+            keys << key
+            iterables << iterable
+        }
+        this.keys = keys
+        this.valuesGenerator = new TupleGenerator(iterables)
+    }
+
+    DefinedMapGenerator(List<K> keys,  TupleGenerator<V> valuesGenerator) {
+        int values = valuesGenerator.generators.size()
+        if (keys.size() != values) {
+            throw new IllegalArgumentException("Keys size (${keys.size()}) does not match values size ($values")
+        }
+        this.keys = keys.collect() //defensive copy
+        this.valuesGenerator = valuesGenerator
     }
 
     @Override
     UnmodifiableIterator<Map<K, V>> iterator() {
-        final Map<K, Iterator<V>> COLLECTOR = [:]
 
         new UnmodifiableIterator<Map<K, V>>() {
-            final private Map<K, Iterator<V>> iteratorMap = keysToValueGenerators.collectEntries(COLLECTOR) { k, v ->
-                [k, v.iterator()]
-            }
+            final private Iterator<List<V>> iterator = valuesGenerator.iterator()
 
             @Override
             boolean hasNext() {
-                iteratorMap.every { key, generator ->
-                    generator.hasNext()
-                }
+                iterator.hasNext()
             }
 
             @Override
             Map<K, V> next() {
-                iteratorMap.collectEntries { key, generator ->
-                    [key, generator.next()]
+                List values = iterator.next()
+                Map<K,V> result = [:]
+                keys.eachWithIndex{ K key, int i ->
+                    result[key] = values[i]
                 }
+                result
             }
         }
     }
 
+    DefinedMapGenerator<K,V> permute() {
+        new DefinedMapGenerator<K, V>(keys, valuesGenerator.permute())
+    }
+
+    DefinedMapGenerator<K,V> permute(int maxDepth) {
+        new DefinedMapGenerator<K, V>(keys, valuesGenerator.permute(maxDepth))
+    }
+
     boolean isFinite() {
-        keysToValueGenerators.any { k, generator -> generator.finite }
+        valuesGenerator.finite
     }
 
     @Override
     DefinedMapGenerator<K, V> seed(Long seed) {
-        keysToValueGenerators.each { k, generator -> generator.seed(seed) }
+        valuesGenerator.seed(seed)
         super.seed(seed)
         this
     }

--- a/src/main/groovy/spock/genesis/generators/composites/PermutationGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/composites/PermutationGenerator.groovy
@@ -16,8 +16,7 @@ class PermutationGenerator<E> extends TupleGenerator<E> {
     }
 
     PermutationGenerator(List<Generator<E>> generators) {
-        super(generators)
-        this.maxDepth = pickMaxDepth(generators)
+        this(generators, pickMaxDepth(generators))
     }
 
     @Override
@@ -35,7 +34,7 @@ class PermutationGenerator<E> extends TupleGenerator<E> {
 
             @Override
             boolean hasNext() {
-                if (emitted == []) {
+                if (!emitted) {
                     //first
                     ITERATORS.every { it.hasNext() }
                 } else if (emittedIterator?.hasNext() || ITERATORS[column].hasNext()) {

--- a/src/main/groovy/spock/genesis/generators/composites/PermutationGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/composites/PermutationGenerator.groovy
@@ -2,10 +2,11 @@ package spock.genesis.generators.composites
 
 import groovy.transform.CompileStatic
 import spock.genesis.generators.Generator
+import spock.genesis.generators.Permutable
 import spock.genesis.generators.UnmodifiableIterator
 
 @CompileStatic
-class PermutationGenerator<E> extends TupleGenerator<E> {
+class PermutationGenerator<E> extends TupleGenerator<E> implements Permutable {
 
     static final int MAX_PERMUTATIONS = 10000
     private final int maxDepth

--- a/src/main/groovy/spock/genesis/generators/composites/PermutationGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/composites/PermutationGenerator.groovy
@@ -1,0 +1,97 @@
+package spock.genesis.generators.composites
+
+import groovy.transform.CompileStatic
+import spock.genesis.generators.Generator
+import spock.genesis.generators.UnmodifiableIterator
+
+@CompileStatic
+class PermutationGenerator<E> extends TupleGenerator<E> {
+
+    static final int MAX_PERMUTATIONS = 10000
+    private final int maxDepth
+
+    PermutationGenerator(List<Generator<E>> generators, int maxDepth) {
+        super(generators)
+        this.maxDepth = maxDepth
+    }
+
+    PermutationGenerator(List<Generator<E>> generators) {
+        super(generators)
+        this.maxDepth = pickMaxDepth(generators)
+    }
+
+    @Override
+    UnmodifiableIterator<List<E>> iterator() {
+        final List<UnmodifiableIterator<E>> ITERATORS = generators.collect { generator ->
+            generator.take(maxDepth).iterator()
+        }
+
+        new UnmodifiableIterator<List<E>>() {
+            private final List<List<E>> emitted = []
+            private final List<List<E>> currentEmmited = []
+            private int column = 0
+            private E value
+            private Iterator<List<E>> emittedIterator
+
+            @Override
+            boolean hasNext() {
+                if (emitted == []) {
+                    //first
+                    ITERATORS.every { it.hasNext() }
+                } else if (emittedIterator?.hasNext() || ITERATORS[column].hasNext()) {
+                    true
+                } else {
+                    //find a column that still has values to generate
+                    while (!ITERATORS[column].hasNext() && column + 1 < ITERATORS.size()) {
+                        column++
+                    }
+                    if (ITERATORS[column].hasNext()) {
+                        emittedIterator = null
+                        emitted.addAll(currentEmmited) // the previous columns emitted tuples for substitution
+                        currentEmmited.clear()
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+
+            @Override
+            List<E> next() {
+                if (emitted) {
+                    if (!emittedIterator?.hasNext()) { // done with the value
+                        value = ITERATORS[column].next() // get the next value
+                        emittedIterator = emitted.iterator()
+                    }
+
+                    List result = emittedIterator.next().collect() // copy the next previously emitted tuple
+                    result[column] = value // substitute the value
+                    currentEmmited << result // keep track of values for this column
+                    result.collect()
+                } else { //first
+                    List result = ITERATORS.collect { it.next() }
+                    emitted << result
+                    result.collect()
+                }
+            }
+        }
+    }
+
+    private static int pickMaxDepth(List<Generator<E>> generators) {
+        Math.floor(nthRoot(MAX_PERMUTATIONS, generators.size()))
+    }
+
+    private static double nthRoot(int base, int exponent) {
+        double tolerance = 0.01
+        double approximation = 1
+        double root
+        while (true) {
+            root = ((exponent - 1) * approximation + base / (approximation) ** (exponent - 1)) / exponent
+            if ((root - approximation).abs() < tolerance) {
+                break
+            }
+            approximation = root
+        }
+        root
+    }
+}

--- a/src/main/groovy/spock/genesis/generators/composites/TupleGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/composites/TupleGenerator.groovy
@@ -8,7 +8,7 @@ import spock.genesis.generators.UnmodifiableIterator
 @CompileStatic
 class TupleGenerator<T> extends Generator<List<T>> implements Closeable {
 
-    private final List<Generator<T>> generators
+    protected final List<Generator<T>> generators
 
     TupleGenerator(List<Iterable<T>> iterables) {
         List<Generator<T>> collector = []

--- a/src/main/groovy/spock/genesis/generators/composites/TupleGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/composites/TupleGenerator.groovy
@@ -3,10 +3,11 @@ package spock.genesis.generators.composites
 import groovy.transform.CompileStatic
 import spock.genesis.extension.ExtensionMethods
 import spock.genesis.generators.Generator
+import spock.genesis.generators.Permutable
 import spock.genesis.generators.UnmodifiableIterator
 
 @CompileStatic
-class TupleGenerator<T> extends Generator<List<T>> implements Closeable {
+class TupleGenerator<T> extends Generator<List<T>> implements Closeable, Permutable {
 
     protected final List<Generator<T>> generators
 

--- a/src/main/groovy/spock/genesis/generators/composites/TupleGenerator.groovy
+++ b/src/main/groovy/spock/genesis/generators/composites/TupleGenerator.groovy
@@ -36,6 +36,14 @@ class TupleGenerator<T> extends Generator<List<T>> implements Closeable {
         }
     }
 
+    PermutationGenerator<T> permute() {
+        new PermutationGenerator<T>(generators)
+    }
+
+    PermutationGenerator<T> permute(int maxDepth) {
+        new PermutationGenerator<T>(generators, maxDepth)
+    }
+
     @Override
     boolean isFinite() {
         generators.every { it.finite }

--- a/src/test/groovy/spock/genesis/generators/composites/DefinedMapGeneratorSpec.groovy
+++ b/src/test/groovy/spock/genesis/generators/composites/DefinedMapGeneratorSpec.groovy
@@ -58,4 +58,33 @@ class DefinedMapGeneratorSpec extends Specification {
         where:
             seed = 100L
     }
+
+    def 'generates all permutations'() {
+        given:
+            def mapDefinition = [int: [1, 2, 3], string:['a', 'b', 'c']]
+            def generator = new DefinedMapGenerator(mapDefinition).permute()
+        expect:
+            generator.collect() == [
+                    [int: 1, string: 'a'],
+                    [int: 2, string: 'a'],
+                    [int: 3, string: 'a'],
+                    [int: 1, string: 'b'],
+                    [int: 2, string: 'b'],
+                    [int: 3, string: 'b'],
+                    [int: 1, string: 'c'],
+                    [int: 2, string: 'c'],
+                    [int: 3, string: 'c']]
+    }
+
+    def 'generates permutations'() {
+        given:
+            def mapDefinition = [int: [1, 2, 3], string: ['a']]
+            def generator = new DefinedMapGenerator(mapDefinition).permute()
+        expect:
+            generator.collect() == [
+                    [int: 1, string: 'a'],
+                    [int: 2, string: 'a'],
+                    [int: 3, string: 'a'],
+            ]
+    }
 }

--- a/src/test/groovy/spock/genesis/generators/composites/PermutationGeneratorSpec.groovy
+++ b/src/test/groovy/spock/genesis/generators/composites/PermutationGeneratorSpec.groovy
@@ -1,0 +1,56 @@
+package spock.genesis.generators.composites
+
+import spock.genesis.Gen
+
+import spock.lang.Specification
+
+class PermutationGeneratorSpec extends Specification {
+
+    def 'generates all permutations'() {
+        given:
+            def generators = [[1, 2, 3].toGenerator(), ['a', 'b', 'c'].toGenerator()]
+            def generator = new PermutationGenerator(generators)
+        expect:
+            generator.collect() == [
+                    [1, 'a'],
+                    [2, 'a'],
+                    [3, 'a'],
+                    [1, 'b'],
+                    [2, 'b'],
+                    [3, 'b'],
+                    [1, 'c'],
+                    [2, 'c'],
+                    [3, 'c']]
+    }
+
+    def 'generates permutations'() {
+        given:
+            def generators = [[1, 2, 3].toGenerator(), ['a'].toGenerator()]
+            def generator = new PermutationGenerator(generators)
+        expect:
+            generator.collect() == [
+                    [1, 'a'],
+                    [2, 'a'],
+                    [3, 'a'],
+                    ]
+    }
+
+    def 'permutations are capped at the generator count root of 10000'() {
+        given:
+            def generators = []
+            generatorCount.times { generators.add(Gen.integer) }
+            def generator = new PermutationGenerator(generators)
+        expect:
+            generator.collect().size() == permutations
+        where:
+            generatorCount | permutations
+            1              | 10000
+            2              | 10000
+            3              | 9261
+            4              | 10000
+            5              | 7776
+            6              | 4096
+            7              | 2187
+            8              | 6561
+    }
+}

--- a/src/test/groovy/spock/genesis/generators/composites/PojoGeneratorSpec.groovy
+++ b/src/test/groovy/spock/genesis/generators/composites/PojoGeneratorSpec.groovy
@@ -1,5 +1,7 @@
 package spock.genesis.generators.composites
 
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
 import spock.genesis.Gen
 import spock.genesis.generators.test.Pojo
 import spock.lang.Specification
@@ -141,6 +143,63 @@ class PojoGeneratorSpec extends Specification {
 
     }
 
+    def 'permute is possible with map generator'() {
+        setup:
+            def generator = new PojoGenerator(MapConstructorObj, Gen.map(string: ['a', 'b'], integer: [1,2,3]))
+        expect:
+            generator.permute().collect() == [
+                    new MapConstructorObj(string: 'a', integer: 1),
+                    new MapConstructorObj(string: 'b', integer: 1),
+                    new MapConstructorObj(string: 'a', integer: 2),
+                    new MapConstructorObj(string: 'b', integer: 2),
+                    new MapConstructorObj(string: 'a', integer: 3),
+                    new MapConstructorObj(string: 'b', integer: 3),
+            ]
+        and: 'only to depth of 2'
+            generator.permute(2).collect() == [
+                    new MapConstructorObj(string: 'a', integer: 1),
+                    new MapConstructorObj(string: 'b', integer: 1),
+                    new MapConstructorObj(string: 'a', integer: 2),
+                    new MapConstructorObj(string: 'b', integer: 2),
+            ]
+    }
+
+    def 'permute is possible with tuple generator'() {
+        setup:
+            def generator = new PojoGenerator(TupleConstructorObj, Gen.tuple(['a', 'b'], [1, 2, 3]))
+        expect:
+            generator.permute().collect() == [
+                    new TupleConstructorObj('a', 1),
+                    new TupleConstructorObj('b', 1),
+                    new TupleConstructorObj('a', 2),
+                    new TupleConstructorObj('b', 2),
+                    new TupleConstructorObj('a', 3),
+                    new TupleConstructorObj('b', 3),
+            ]
+        and: 'only to depth of 2'
+            generator.permute(2).collect() == [
+                    new TupleConstructorObj('a', 1),
+                    new TupleConstructorObj('b', 1),
+                    new TupleConstructorObj('a', 2),
+                    new TupleConstructorObj('b', 2),
+            ]
+    }
+
+    def 'permute does not work on iterable'() {
+        setup:
+            def generator = new PojoGenerator(TupleConstructorObj, [['a', 1], ['b', 2]])
+        when:
+            generator.permute()
+        then:
+            thrown(UnsupportedOperationException)
+        when:
+            generator.permute(1)
+        then:
+            thrown(UnsupportedOperationException)
+    }
+
+    @EqualsAndHashCode
+    @ToString
     static class TupleConstructorObj {
         String string
         Integer integer
@@ -151,6 +210,8 @@ class PojoGeneratorSpec extends Specification {
         }
     }
 
+    @EqualsAndHashCode
+    @ToString
     static class MapConstructorObj {
         String string
         Integer integer


### PR DESCRIPTION
This is still a work in progress. It needs expansion to include permutations for defined Map and Pojo generators. Those can be built on top of the tuple generator though. This is also only depth first. There also would need to be docs and the permute method added to the relevent classes. I think it should target the 0.6 version because of the remaining work.
@drdamour

cc @mariogarcia  
