### PR TITLE
Modified test to increase test coverage of ByteArrayGenerator

### DIFF
--- a/src/test/groovy/spock/genesis/generators/values/ByteArrayGeneratorSpec.groovy
+++ b/src/test/groovy/spock/genesis/generators/values/ByteArrayGeneratorSpec.groovy
@@ -7,9 +7,13 @@ class ByteArrayGeneratorSpec extends Specification {
     def 'setting seed produces the same sequences for different generators' () {
         given:
             def a = new ByteArrayGenerator().seed(seed).take(100).realized
-            def b = new ByteArrayGenerator().seed(seed).take(100).realized
+            def b = new ByteArrayGenerator(ByteArrayGenerator.DEFAULT_LENGTH_LIMIT).seed(seed).take(100).realized
+            def c = new ByteArrayGenerator(0, ByteArrayGenerator.DEFAULT_LENGTH_LIMIT).seed(seed).take(100).realized
+            def d = new ByteArrayGenerator((0..ByteArrayGenerator.DEFAULT_LENGTH_LIMIT) as IntRange).seed(seed).take(100).realized
         expect:
             a == b
+            b == c
+            c == d
         where:
             seed << [Long.MIN_VALUE, 100, Long.MAX_VALUE]
     }


### PR DESCRIPTION
This very basic change was done while playing around with the code coverage report. It brings the coverage metric up for the ByteArrayGenerator class.